### PR TITLE
remove PowerShell.TMLanguage conversion, dedicate to PowerShell->PList converter

### DIFF
--- a/ConvertTo-PList.ps1
+++ b/ConvertTo-PList.ps1
@@ -12,7 +12,7 @@
 .PARAMETER IndentFirstItem
     A switch causing the first level of objects to be indented as per normal XML practices.
 .EXAMPLE
-    $grammar_json | ConvertTo-Plist -Indent "`t" -StateEncodingAs 'UTF-8' | Set-Content 'out\PowerShellSyntax.tmLanguage' -Encoding 'UTF8'
+    $grammar_json | ConvertTo-Plist -Indent `t -StateEncodingAs UTF-8 | Set-Content out\PowerShellSyntax.tmLanguage -Encoding UTF8
 .INPUTS
     [object] - containing the PList as conventional PowerShell object types, hashtables, arrays, strings, numeric values, and byte arrays.
 .OUTPUTS
@@ -27,9 +27,7 @@
 #>
 function ConvertTo-PList
 (
-    [Parameter(Mandatory,
-        ValueFromPipeline,
-        ValueFromPipelineByPropertyName)]
+    [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
     [AllowEmptyCollection()]
     [AllowNull()]
     [AllowEmptyString()]
@@ -38,7 +36,7 @@ function ConvertTo-PList
     [PSDefaultValue(Help = 'Tab')]
     [string]$Indent = "`t",
 
-    [string]$StateEncodingAs = "UTF-8",
+    [string]$StateEncodingAs = 'UTF-8',
 
     [switch]$IndentFirstItem
 ) {
@@ -115,7 +113,7 @@ function ConvertTo-PList
 
         # write out key name, if one was supplied
         if ($name) {
-            "$level<key>$($item | writeXMLcontent)</key>"
+            "$level<key>$($name | writeXMLcontent)</key>"
         }
         if ($item -is [array]) {
             # handle arrays

--- a/ConvertTo-PList.ps1
+++ b/ConvertTo-PList.ps1
@@ -1,29 +1,15 @@
 # attempt to convert a JSON textmate language file back to PLIST tmLanguage file
 
-# parameters to the script - needs work to support multiple paths  (WIP)
-#[CmdletBinding()]
-#Param(
-#
-#    [Parameter(Mandatory = $false,
-#        Position = 1,
-#        ValueFromPipeline = $false,
-#        ValueFromPipelineByPropertyName = $false,
-#        HelpMessage = "Indention pattern.")]
-#    [ValidateNotNull()]
-#    [string]$Indent = "`t"
-#
-#)
-
 # define a function to create a plist document, trying to keep it as generic as possible
-function ConvertTo-PList 
+function ConvertTo-PList
 (
     [Parameter(Mandatory = $true,
         ValueFromPipeline = $true,
         ValueFromPipelineByPropertyName = $true)]
-    [AllowEmptyCollection() ]
+    [AllowEmptyCollection()]
     [AllowNull()]
     [AllowEmptyString()]
-    [object]$PropertyList, 
+    [object]$PropertyList,
 
     [ValidateNotNull()]
     [string]$Indent = "`t",

--- a/ConvertTo-PList.ps1
+++ b/ConvertTo-PList.ps1
@@ -122,9 +122,14 @@ function ConvertTo-PList
             }
         }
 
-        # write out key name, if one was supplied
-        if ($name) {
-            "$indention<key>$($name | writeXMLcontent)</key>"
+        # write out key name, if one was supplied - or while beyond level 0 (base)
+        if ($level -gt 0) {
+            if ($name) {
+                "$indention<key>$($name | writeXMLcontent)</key>"
+            } else {
+                # no key name was supplied
+                "$indention<key/>"
+            }
         }
         if ($item -is [array]) {
             # handle arrays

--- a/ConvertTo-PList.ps1
+++ b/ConvertTo-PList.ps1
@@ -28,12 +28,15 @@ function ConvertTo-PList
     [ValidateNotNull()]
     [string]$Indent = "`t",
 
+    [string]$StateEncodingAs = "UTF-8",
+
     [switch]$IndentFirstItem
 ) {
     # write out a PList document based on the property list supplied
     # $PropertyList is an object containing the entire property list tree.  Hash tables are supported.
-    # $indent is a string representing the indentation to use.
+    # $Indent is a string representing the indentation to use.
     #   Typically use "`t" or "  ".
+    # $StateencodingAs is a string to supply in the XML header that represents the encoding XML will be represented as in the final file
 
     function writeXMLcontent ([string]$value) {
         # write an escaped XML value, the only characters requiring escape in XML character content
@@ -121,7 +124,7 @@ function ConvertTo-PList
     }
 
     # write the PList Header
-    '<?xml version="1.0" encoding="UTF-8"?>'
+    '<?xml version="1.0"' + $(if ($StateEncodingAs) {' encoding="' + $StateEncodingAs + '"'}) + '?>'
     '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">'
     '<plist version="1.0">'
 

--- a/ConvertTo-PList.ps1
+++ b/ConvertTo-PList.ps1
@@ -117,7 +117,7 @@ function ConvertTo-PList
                 "$indention</dict>"
             } else {
                 # object has reached maximum depth, cast it out as a string
-                "$indention<string>$($item | writeXMLcontent)</string>"
+                writevalue "$item" "$indention"
             }
         }
 
@@ -142,7 +142,7 @@ function ConvertTo-PList
                 "$indention</array>"
             } else {
                 # object has reached maximum depth, cast it out as a string
-                "$indention<string>$($item | writeXMLcontent)</string>"
+                writevalue "$item" "$indention"
             }
         } else {
             # handle a single object

--- a/ConvertTo-PList.ps1
+++ b/ConvertTo-PList.ps1
@@ -1,6 +1,30 @@
-# attempt to convert a JSON textmate language file back to PLIST tmLanguage file
-
-# define a function to create a plist document, trying to keep it as generic as possible
+<#
+.SYNOPSIS
+    Convert a PowerShell object to an XML Plist represented in a string.
+.DESCRIPTION
+    Converts a PowerShell object to an XML PList (property list) notation as a string.
+.PARAMETER PropertyList
+    The input PowerShell object to be represented in an XML PList notation.  This parameter may be received from the pipeline.
+.PARAMETER Indent
+    Specifies a string value to be used for each level of the indention within the XML document.
+.PARAMETER StateEncodingAs
+    Specifies a string value to be stated as the value of the `encoding` attribute of the XML document header.  This does not actually set the encoding.
+.PARAMETER IndentFirstItem
+    A switch causing the first level of objects to be indented as per normal XML practices.
+.EXAMPLE
+    $grammar_json | ConvertTo-Plist -Indent "`t" -StateEncodingAs 'UTF-8' | Set-Content 'out\PowerShellSyntax.tmLanguage' -Encoding 'UTF8'
+.INPUTS
+    [object] - containing the PList as conventional PowerShell object types, hashtables, arrays, strings, numeric values, and byte arrays.
+.OUTPUTS
+    [string] - the input object returned in an XML PList notation.
+.NOTES
+    Script / Function / Class assembled by Carl Morris, Morris Softronics, Hooper, NE, USA
+    Initial release - Aug 18, 2018
+.LINK
+    https://github.com/msftrncs/PwshJSONtoPList/
+.FUNCTIONALITY
+    data format conversion
+#>
 function ConvertTo-PList
 (
     [Parameter(Mandatory = $true,
@@ -11,7 +35,6 @@ function ConvertTo-PList
     [AllowEmptyString()]
     [object]$PropertyList,
 
-    [ValidateNotNull()]
     [string]$Indent = "`t",
 
     [string]$StateEncodingAs = "UTF-8",
@@ -117,14 +140,16 @@ function ConvertTo-PList
         }
     }
 
-    # write the PList Header
-    '<?xml version="1.0"' + $(if ($StateEncodingAs) {' encoding="' + (writeXMLvalue $StateEncodingAs) + '"'}) + '?>'
-    '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">'
-    '<plist version="1.0">'
+    $(
+        # write the PList Header
+        '<?xml version="1.0"' + $(if ($StateEncodingAs) {' encoding="' + (writeXMLvalue $StateEncodingAs) + '"'}) + '?>'
+        '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">'
+        '<plist version="1.0">'
 
-    # start writing the property list, the property list should be an object, has no name, and starts at base level
-    writeproperty $null $PropertyList $(if ($IndentFirstItem.IsPresent) {$Indent} else {""} )
+        # start writing the property list, the property list should be an object, has no name, and starts at base level
+        writeproperty $null $PropertyList $(if ($IndentFirstItem.IsPresent) {$Indent} else {""} )
 
-    # end the PList document
-    '</plist>'
+        # end the PList document
+        '</plist>'
+    ) -join "`r`n"
 }

--- a/ConvertTo-PList.ps1
+++ b/ConvertTo-PList.ps1
@@ -1,31 +1,32 @@
 # attempt to convert a JSON textmate language file back to PLIST tmLanguage file
 
 # parameters to the script - needs work to support multiple paths  (WIP)
-[CmdletBinding()]
-Param(
-
-    # Specifies a path to one or more locations. Wildcards are permitted.
-    [Parameter(Mandatory = $true,
-        Position = 0,
-        ValueFromPipeline = $true,
-        ValueFromPipelineByPropertyName = $true,
-        HelpMessage = "Path to one or more locations.")]
-    [ValidateNotNullOrEmpty()]
-    [SupportsWildcards()]
-    [string[]]$Path,
-
-    [Parameter(Mandatory = $false,
-        Position = 1,
-        ValueFromPipeline = $false,
-        ValueFromPipelineByPropertyName = $false,
-        HelpMessage = "Indention pattern.")]
-    [ValidateNotNull()]
-    [string]$Indent = "`t"
-
-)
+#[CmdletBinding()]
+#Param(
+#
+#    [Parameter(Mandatory = $false,
+#        Position = 1,
+#        ValueFromPipeline = $false,
+#        ValueFromPipelineByPropertyName = $false,
+#        HelpMessage = "Indention pattern.")]
+#    [ValidateNotNull()]
+#    [string]$Indent = "`t"
+#
+#)
 
 # define a function to create a plist document, trying to keep it as generic as possible
-function ConvertTo-PList ($PropertyList, [string]$indent) {
+function ConvertTo-PList 
+(
+    [Parameter(Mandatory = $true,
+        ValueFromPipeline = $true,
+        ValueFromPipelineByPropertyName = $true)]
+    $PropertyList, 
+
+    [ValidateNotNull()]
+    [string]$Indent = "`t",
+
+    [switch]$IndentFirstItem
+) {
     # write out a PList document based on the property list supplied
     # $PropertyList is an object containing the entire property list tree.  Hash tables are supported.
     # $indent is a string representing the indentation to use.
@@ -82,7 +83,7 @@ function ConvertTo-PList ($PropertyList, [string]$indent) {
                 "$level<dict>"
                 # iterate through the items (force to a PSCustomObject for consistency)
                 foreach ($property in ([PSCustomObject]$item).psobject.Properties) {
-                    writeproperty $property.Name $property.Value "$level$indent"
+                    writeproperty $property.Name $property.Value "$level$Indent"
                 }
                 "$level</dict>"
             }
@@ -98,14 +99,14 @@ function ConvertTo-PList ($PropertyList, [string]$indent) {
                 # handle an array of bytes, encode as BASE64 string, write as DATA block
                 # use REGEX to split out the string in to 44 character chunks properly indented
                 "$level<data>"
-                [regex]::Matches([convert]::ToBase64String($item), '(.{1,44})').value.foreach( {"$level$indent$_"} )
+                [regex]::Matches([convert]::ToBase64String($item), '(.{1,44})').value.foreach( {"$level$Indent$_"} )
                 "$level</data>"
             }
             else {
                 "$level<array>"
                 # iterate through the items in the array
                 foreach ($subitem in $item) {
-                    writevalue $subitem "$level$indent"
+                    writevalue $subitem "$level$Indent"
                 }
                 "$level</array>"
             }
@@ -122,34 +123,8 @@ function ConvertTo-PList ($PropertyList, [string]$indent) {
     '<plist version="1.0">'
 
     # start writing the property list, the property list should be an object, has no name, and starts at base level
-    writeproperty $null $PropertyList ""
+    writeproperty $null $PropertyList $(if ($IndentFirstItem.IsPresent) {$Indent} else {""} )
 
     # end the PList document
     '</plist>'
-}
-
-<# this lists out the first level of properties to create the PList document from, and also gives the output order of the first level.
-$FirstLevelObjects = @(
-    'name'
-    'patterns'
-    'repository'
-    'scopeName'
-) #>
-
-# from here on, we're converting the PowerShell.tmLanguage.JSON file to PLIST with hardcoded conversion requirements
-foreach ($file in $Path) {
-
-    # start by reading in the file through ConvertFrom-JSON
-    $grammer_json = Get-Content $file | ConvertFrom-Json
-
-    # write the PList document from a custom made object, supplying some data missing from the JSON file, ignoring some JSON objects
-    # and reordering the items that remain.
-    ConvertTo-Plist ([ordered]@{
-            fileTypes                                            = @('ps1', 'psm1', 'psd1')
-            $grammer_json.psobject.Properties['name'].Name       = $grammer_json.psobject.Properties['name'].Value
-            $grammer_json.psobject.Properties['patterns'].Name   = $grammer_json.psobject.Properties['patterns'].Value
-            $grammer_json.psobject.Properties['repository'].Name = $grammer_json.psobject.Properties['repository'].Value
-            $grammer_json.psobject.Properties['scopeName'].Name  = $grammer_json.psobject.Properties['scopeName'].Value
-            uuid                                                 = 'f8f5ffb0-503e-11df-9879-0800200c9a66'
-        }) $Indent
 }

--- a/ConvertTo-PList.ps1
+++ b/ConvertTo-PList.ps1
@@ -71,36 +71,30 @@ function ConvertTo-PList
             if (($item -is [string]) -or ($item -is [char])) {
                 # handle strings or characters
                 "$level<string>$($item | writeXMLcontent)</string>"
-            }
-            elseif ($item -is [boolean]) {
+            } elseif ($item -is [boolean]) {
                 # handle boolean type
                 "$level$(
                     if ($item) {
                         "<true/>"
-                    }
-                    else {
+                    } else {
                         "<false/>"
                     }
                 )"
-            }
-            elseif ($item -is [ValueType]) {
+            } elseif ($item -is [ValueType]) {
                 # handle numeric types
                 "$level$(
                     if (($item -is [single]) -or ($item -is [double]) -or ($item -is [decimal])) {
                         # floating point or decimal numeric types
                         "<real>$item</real>"
-                    }
-                    elseif ($item -is [datetime]) {
+                    } elseif ($item -is [datetime]) {
                         # date and time numeric type
-                        "<date>$($item | writeXMLcontent)</date>"
-                    }
-                    else {
+                        "<date>$($item.ToString('o') | writeXMLcontent)</date>"
+                    } else {
                         # interger numeric types
                         "<integer>$item</integer>"
                     }
                 )"
-            }
-            else {
+            } else {
                 # handle objects by recursing with writeproperty
                 "$level<dict>"
                 # iterate through the items (force to a PSCustomObject for consistency)
@@ -121,10 +115,9 @@ function ConvertTo-PList
                 # handle an array of bytes, encode as BASE64 string, write as DATA block
                 # use REGEX to split out the string in to 44 character chunks properly indented
                 "$level<data>"
-                [regex]::Matches([convert]::ToBase64String($item), '(.{1,44})').value.foreach( {"$level$Indent$_"} )
+                [regex]::Matches([convert]::ToBase64String($item), '(.{1,44})').value.foreach({ "$level$Indent$_" })
                 "$level</data>"
-            }
-            else {
+            } else {
                 "$level<array>"
                 # iterate through the items in the array
                 foreach ($subitem in $item) {
@@ -132,8 +125,7 @@ function ConvertTo-PList
                 }
                 "$level</array>"
             }
-        }
-        else {
+        } else {
             # handle a single object
             Writevalue $item $level
         }
@@ -141,14 +133,14 @@ function ConvertTo-PList
 
     $(
         # write the PList Header
-        '<?xml version="1.0"' + $(if ($StateEncodingAs) {' encoding="' + ($StateEncodingAs | writeXMLvalue) + '"'}) + '?>'
+        '<?xml version="1.0"' + $(if ($StateEncodingAs) { ' encoding="' + ($StateEncodingAs | writeXMLvalue) + '"' }) + '?>'
         '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">'
         '<plist version="1.0">'
 
         # start writing the property list, the property list should be an object, has no name, and starts at base level
-        writeproperty $null $PropertyList $(if ($IndentFirstItem.IsPresent) {$Indent} else {""})
+        writeproperty $null $PropertyList $(if ($IndentFirstItem.IsPresent) { $Indent } else { "" })
 
         # end the PList document
         '</plist>'
-    ) -join $(if (-not $IsCoreCLR -or $IsWindows) {"`r`n"} else {"`n"})
+    ) -join $(if (-not $IsCoreCLR -or $IsWindows) { "`r`n" } else { "`n" })
 }

--- a/ConvertTo-PList.ps1
+++ b/ConvertTo-PList.ps1
@@ -20,7 +20,10 @@ function ConvertTo-PList
     [Parameter(Mandatory = $true,
         ValueFromPipeline = $true,
         ValueFromPipelineByPropertyName = $true)]
-    $PropertyList, 
+    [AllowEmptyCollection() ]
+    [AllowNull()]
+    [AllowEmptyString()]
+    [object]$PropertyList, 
 
     [ValidateNotNull()]
     [string]$Indent = "`t",

--- a/ConvertTo-PList.ps1
+++ b/ConvertTo-PList.ps1
@@ -22,7 +22,7 @@ function ConvertTo-PList
     # $PropertyList is an object containing the entire property list tree.  Hash tables are supported.
     # $Indent is a string representing the indentation to use.
     #   Typically use "`t" or "  ".
-    # $StateencodingAs is a string to supply in the XML header that represents the encoding XML will 
+    # $StateEncodingAs is a string to supply in the XML header that represents the encoding XML will
     # be represented as in the final file
 
     function writeXMLcontent ([string]$value) {

--- a/ConvertTo-PList.ps1
+++ b/ConvertTo-PList.ps1
@@ -103,15 +103,16 @@ function ConvertTo-PList
                 # handle objects by recursing with writeproperty
                 "$indention<dict>"
                 # iterate through the items
-                if ($item -is [pscustomobject]) {
-                    # process a custom object's properties
-                    foreach ($property in $item.psobject.Properties) {
-                        writeproperty $property.Name $property.Value "$indention$Indent" ($level + 1)
-                    }
-                } else {
+                if ($item.GetType().Name -in 'HashTable', 'OrderedDictionary') {
                     # process what we assume is a hashtable object
                     foreach ($key in $item.Keys) {
                         writeproperty $key $item[$key] "$indention$Indent" ($level + 1)
+                    }
+                }
+                else {
+                    # process a custom object's properties
+                    foreach ($property in [PSCustomObject]$item.psobject.Properties) {
+                        writeproperty $property.Name $property.Value "$indention$Indent" ($level + 1)
                     }
                 }
                 "$indention</dict>"

--- a/ConvertTo-PList.ps1
+++ b/ConvertTo-PList.ps1
@@ -36,13 +36,21 @@ function ConvertTo-PList
     # $PropertyList is an object containing the entire property list tree.  Hash tables are supported.
     # $Indent is a string representing the indentation to use.
     #   Typically use "`t" or "  ".
-    # $StateencodingAs is a string to supply in the XML header that represents the encoding XML will be represented as in the final file
+    # $StateencodingAs is a string to supply in the XML header that represents the encoding XML will 
+    # be represented as in the final file
 
     function writeXMLcontent ([string]$value) {
-        # write an escaped XML value, the only characters requiring escape in XML character content
+        # write an escaped XML content, the only characters requiring escape in XML character content
         # are &lt; and &amp;, but we'll escape &gt; as well for good habit.
         # the purpose of making this a function, is a single place to change the escaping function used
         $value -replace '&', '&amp;' -replace '<', '&lt;' -replace '>', '&gt;'
+    }
+
+    function writeXMLvalue ([string]$value) {
+        # write an escaped XML value, the only characters requiring escape in XML attribute values
+        # are &lt; and &amp; and &quo, but we'll escape &gt; as well for good habit.
+        # the purpose of making this a function, is a single place to change the escaping function used
+        (writeXMLcontent $value) -replace '"', '&quot;'
     }
 
     function writeproperty ([string]$name, $item, [string]$level) {
@@ -124,7 +132,7 @@ function ConvertTo-PList
     }
 
     # write the PList Header
-    '<?xml version="1.0"' + $(if ($StateEncodingAs) {' encoding="' + $StateEncodingAs + '"'}) + '?>'
+    '<?xml version="1.0"' + $(if ($StateEncodingAs) {' encoding="' + (writeXMLvalue $StateEncodingAs) + '"'}) + '?>'
     '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">'
     '<plist version="1.0">'
 

--- a/ConvertTo-PList.ps1
+++ b/ConvertTo-PList.ps1
@@ -147,7 +147,7 @@ function ConvertTo-PList
         '<plist version="1.0">'
 
         # start writing the property list, the property list should be an object, has no name, and starts at base level
-        writeproperty $null $PropertyList $(if ($IndentFirstItem.IsPresent) {$Indent} else {""} )
+        writeproperty $null $PropertyList $(if ($IndentFirstItem.IsPresent) {$Indent} else {""})
 
         # end the PList document
         '</plist>'

--- a/ConvertTo-PList.ps1
+++ b/ConvertTo-PList.ps1
@@ -66,7 +66,7 @@ function ConvertTo-PList
         ($_ | writeXMLcontent) -replace '"', '&quot;'
     }
 
-    function writeproperty ([string]$name, $item, [string]$indention, [int32]$level) {
+    function writeproperty ([string]$name, $item, [string]$indention, [int32]$level, [switch]$NoKey) {
         # writing the property may require recursively breaking down the objects based on their type
         # name of the property is optional, but that is only intended for the first property object
 
@@ -108,8 +108,7 @@ function ConvertTo-PList
                     foreach ($key in $item.Keys) {
                         writeproperty $key $item[$key] "$indention$Indent" ($level + 1)
                     }
-                }
-                else {
+                } else {
                     # process a custom object's properties
                     foreach ($property in [PSCustomObject]$item.psobject.Properties) {
                         writeproperty $property.Name $property.Value "$indention$Indent" ($level + 1)
@@ -123,7 +122,7 @@ function ConvertTo-PList
         }
 
         # write out key name, if one was supplied - or while beyond level 0 (base)
-        if ($level -gt 0) {
+        if (-not $NoKey) {
             if ($name) {
                 "$indention<key>$($name | writeXMLcontent)</key>"
             } else {
@@ -143,7 +142,7 @@ function ConvertTo-PList
                 "$indention<array>"
                 # iterate through the items in the array
                 foreach ($subitem in $item) {
-                    writeproperty '' $subitem "$indention$Indent" ($level + 1)
+                    writeproperty '' $subitem "$indention$Indent" ($level + 1) -NoKey
                 }
                 "$indention</array>"
             } else {
@@ -163,7 +162,7 @@ function ConvertTo-PList
         '<plist version="1.0">'
 
         # start writing the property list, the property list should be an object, has no name, and starts at base level
-        writeproperty '' $PropertyList $(if ($IndentFirstItem.IsPresent) { $Indent } else { '' }) 0
+        writeproperty '' $PropertyList $(if ($IndentFirstItem.IsPresent) { $Indent } else { '' }) 0 -NoKey
 
         # end the PList document
         '</plist>'

--- a/README.md
+++ b/README.md
@@ -1,15 +1,50 @@
-# PwshJSONtoPList
+# PwshJSONtoPList - ConvertTo-PList
 
-Powershell function to convert PowerShell.tmLanguage.JSON file to XML PList.
+Convert a PowerShell object to an XML PList.
 
-Within it is a fairly complete XML PList generator function.
+Originally intended for the conversion of JSON based tmLanguage grammar definitions to the formal tmLanguage PLIST format.
 
-Its intention is to convert the VS Code PowerShell tmLanguage language syntax file back to XML PList format after edited as a JSON file.
+Example based on JSON tmLanguage file.
+
+```PowerShell
+Get-Content "powershell.tmlanguage.json" | ConvertFrom-Json |
+    ConvertTo-Plist -Indent "`t" -StateEncodingAs 'UTF-8' |
+    Set-Content 'out\PowerShellSyntax.tmLanguage' -Encoding 'UTF8'
+```
+
+```PowerShell
+$grammar_json = Get-Content "powershell.tmlanguage.json" | ConvertFrom-Json
+ConvertTo-Plist $grammar_json -Indent "`t" -StateEncodingAs 'UTF-8' |
+    Set-Content 'out\PowerShellSyntax.tmLanguage' -Encoding 'UTF8'
+```
+
+```PowerShell
+[xml]$grammar_xml = Get-Content "powershell.tmlanguage.json" | ConvertFrom-Json |
+    ConvertTo-Plist -Indent "`t" -StateEncodingAs $null 
+```
+
+### Parameters
+
+#### PropertyList
+
+The PowerShell object which possesses the items for the PLIST.  This can be any object that can be represented as a PSCustomObject.  This parameter may be received from the pipeline.
+
+#### Indent
+
+Specifies the indentation to use when generating the XML output.  The default is ```"`t"``` (tab), but other usual options are `''` (none), `'    '` (4 spaces), but otherwise any string is accepted, and no escaping is performed.
+
+#### StateEncodingAs
+
+Specifies the encoding to state in the XML header.  This does not actually set the encoding as this function does not directly produce encoded output.  See the examples above.  The default is 'UTF-8'.  Specify `$null` to remove the `encoding` attribute from the header.
+
+#### IndentFirstItem
+
+A switch that specifies that the first item level of the PLIST XML is to be indented.  Most PLIST files do not have the first item level indented, but a formal XML writer would normally do this.
+
+### Output
+
+The output of this function is an array of strings (`[string[]]`).  Use Out-File or Set-Content and be sure to assign the correct encoding.  You may also use the `[xml]` accelerator when assigning the output to a variable, and then use XML cmdlets or tools on the result.
 
 Note:
 - Escapes only '&lt;', '&amp;' and '&gt;'.
 - The PList XML generator should be complete, with regard to item data type handling.
-- the indentation of the XML is adjustable.
-- The XML document's encoding is hardset as 'encoding="UTF-8"', but might not match the actual output.
-- The resulting XML is output to the stdout (console).
-- The script has parameters for path to the .tmLanguage.JSON file, which accepts wildcards and arrays, but this is a Work In Progress.

--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ A switch that specifies that the first item level of the PLIST XML is to be inde
 
 ### Output
 
-The output of this function is an array of strings (`[string[]]`).  Use Out-File or Set-Content and be sure to assign the correct encoding.  You may also use the `[xml]` accelerator when assigning the output to a variable, and then use XML cmdlets or tools on the result.
+The output of this function is a single string (`[string]`).  Use Out-File or Set-Content and be sure to assign the correct encoding.  You may also use the `[xml]` accelerator when assigning the output to a variable, and then use XML cmdlets or tools on the result.
 
 Note:
 - Escapes only '&lt;', '&amp;' and '&gt;'.
 - The PList XML generator should be complete, with regard to item data type handling.
+- Objects that possess recursive backreferences (loops) will lock up the function.  There is no `-Depth` parameter yet.


### PR DESCRIPTION
Merge the work branch back in to master, ConvertTo-Plist function is now solely based as a generic PowerShell object to XML PLIST converter.