### PR TITLE
Reorganize, fix and improve

### DIFF
--- a/ConvertTo-PList.ps1
+++ b/ConvertTo-PList.ps1
@@ -15,6 +15,12 @@
     A switch causing the first level of objects to be indented as per normal XML practices.
 .PARAMETER EnumsAsStrings
     A switch that specifies an alternate serialization option that converts all enumerations to their string representations.
+.PARAMETER FormatDataInlineMaxLength
+    Maximum encoded <data> length for keeping value inline, if unspecified, all data will be nested and wrapped, if 0, all data will be inline.
+.PARAMETER FormatDataWrapMaxLength
+    Maximum ecnoded <data> length for each nested wrapped line once exceeding FormatDataInlineMaxLength, or 0 for all data to be on a single nested line.
+.PARAMETER FormatDataWrappedNoIndent
+    A switch to prevent the indenting of <data> content when nested/wrapped on separate lines.
 .EXAMPLE
     $grammar_json | ConvertTo-Plist -Indent `t -StateEncodingAs UTF-8 | Set-Content out\PowerShellSyntax.tmLanguage -Encoding UTF8
 .INPUTS

--- a/ConvertTo-PList.ps1
+++ b/ConvertTo-PList.ps1
@@ -117,7 +117,7 @@ function ConvertTo-PList
                 "$indention<data>$itemData</data>"    
             } else {
                 "$indention<data>"
-                [regex]::Matches($itemData, '(.{1,44})').Value.foreach({ "$indention$Indent$_" })
+                [regex]::Matches($itemData, '.{1,44}').Value.foreach({ "$indention$Indent$_" })
                 "$indention</data>"
             }
         } elseif ($level -le $Depth) {

--- a/ConvertTo-PList.ps1
+++ b/ConvertTo-PList.ps1
@@ -133,7 +133,7 @@ function ConvertTo-PList
                 } else {
                     "$indention<array/>" # empty object
                 }
-            } elseif ($item -and $(if($item -is [Collections.IDictionary]) {$item.get_Keys().Count} else {@($item.psobject.get_Properties()).Count}) -gt 0) {
+            } elseif ($item -and $(if($item -is [Collections.IDictionary]) { $item.get_Keys().Count } else { @($item.psobject.get_Properties()).Count} ) -gt 0) {
                 # handle objects by recursing with writeProperty
                 "$indention<dict>"
                 # iterate through the items

--- a/ConvertTo-PList.ps1
+++ b/ConvertTo-PList.ps1
@@ -55,7 +55,7 @@ function ConvertTo-PList
     [ValidateRange(0,1000)]
     [uint32]$FormatDataWrapMaxLength = 44,
 
-    [switch]$FormatDataIndentWrapped
+    [switch]$FormatDataWrappedNoIndent
 ) {
     # write out a PList document based on the property list supplied
     # $PropertyList is an object containing the entire property list tree.  Hash tables are supported.
@@ -129,7 +129,7 @@ function ConvertTo-PList
                 "$indention<data>$itemData</data>"    
             } else {
                 "$indention<data>"
-                $DataWrapperRegex.Matches($itemData).Value.ForEach({ "$indention$(if ($FormatDataIndentWrapped) { $Indent })$_" })
+                $DataWrapperRegex.Matches($itemData).Value.ForEach({ "$indention$(if (!$FormatDataWrappedNoIndent) { $Indent })$_" })
                 "$indention</data>"
             }
         } elseif ($level -le $Depth) {

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ ConvertTo-Plist $grammar_json -Indent "`t" -StateEncodingAs 'UTF-8' |
 
 The PowerShell object which possesses the items for the PLIST.  This can be any object that can be represented as a PSCustomObject.  This parameter may be received from the pipeline.
 
+#### Compress
+
+Omits white space and indented formatting in the output string.  Ignores all further indenting and formatting related parameters.
+
 #### Indent
 
 Specifies the indentation to use when generating the XML output.  The default is ```"`t"``` (tab), but other usual options are `''` (none), `'    '` (4 spaces), but otherwise any string is accepted, and no escaping is performed.
@@ -37,9 +41,29 @@ Specifies the indentation to use when generating the XML output.  The default is
 
 Specifies the encoding to state in the XML header.  This does not actually set the encoding as this function does not directly produce encoded output.  See the examples above.  The default is 'UTF-8'.  Specify `$null` to remove the `encoding` attribute from the header.
 
+#### Depth
+
+Specifies the maximum depth of recursion permitted for the input property list object.
+
 #### IndentFirstItem
 
 A switch that specifies that the first item level of the PLIST XML is to be indented.  Most PLIST files do not have the first item level indented, but a formal XML writer would normally do this.
+
+#### EnumsAsStrings
+
+A switch that specifies an alternate serialization option that converts all enumerations to their string representations.
+
+#### FormatDataInlineMaxLength
+
+Maximum encoded `<data>` length for keeping value inline, if unspecified, all data will be nested and wrapped, if 0, all data will be inline.
+
+#### FormatDataWrapMaxLength
+
+Maximum ecnoded `<data>` length for each nested wrapped line once exceeding FormatDataInlineMaxLength, or 0 for all data to be on a single nested line.
+
+#### FormatDataWrappedNoIndent
+
+A switch to prevent the indenting of `<data>` content when nested/wrapped on separate lines.
 
 ### Output
 
@@ -48,4 +72,3 @@ The output of this function is a single string (`[string]`).  Use Out-File or Se
 Note:
 - Escapes only '&lt;', '&amp;' and '&gt;'.
 - The PList XML generator should be complete, with regard to item data type handling.
-- Objects that possess recursive backreferences (loops) will lock up the function.  There is no `-Depth` parameter yet.


### PR DESCRIPTION
Reorganize internal serialization functions.

Fixes #11, serialize the entire input array when passed on the pipeline.

Fixes #6, Fixes #7, providing several parameters to control formatting of `<data>` elements.

Fixes #10 , providing a EnumsAsStrings parameter, behavior consistent with ConvertTo-Json.

Fixes #9, empty arrays and empty objects now use `<array/>` and `<data/>` self closing notation.

Implement a Compress switch parameter to omit all formatting whitespace and line breaks